### PR TITLE
[feat] 리프레시 토큰 저장 HttpOnly 쿠키로 변경

### DIFF
--- a/src/main/java/com/OEzoa/OEasy/api/member/AuthController.java
+++ b/src/main/java/com/OEzoa/OEasy/api/member/AuthController.java
@@ -5,7 +5,9 @@ import com.OEzoa.OEasy.application.member.dto.AuthTokenResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,8 +35,9 @@ public class AuthController {
             }
     )
     public ResponseEntity<AuthTokenResponseDTO> refreshAccessToken(
-            @RequestHeader(name = "Authorization", required = false) String refreshTokenHeader) {
-        AuthTokenResponseDTO tokens = authService.refreshAccessToken(refreshTokenHeader);
-        return ResponseEntity.ok(tokens);
+            @CookieValue(name = "refreshToken", required = false) String refreshToken,
+            HttpServletResponse response) {
+        String newAccessToken = authService.refreshAccessToken(refreshToken, response);
+        return ResponseEntity.ok(new AuthTokenResponseDTO(newAccessToken));
     }
 }

--- a/src/main/java/com/OEzoa/OEasy/api/member/login/LoginController.java
+++ b/src/main/java/com/OEzoa/OEasy/api/member/login/LoginController.java
@@ -5,12 +5,17 @@ import com.OEzoa.OEasy.application.member.MemberService;
 import com.OEzoa.OEasy.application.member.dto.MemberLoginDTO;
 import com.OEzoa.OEasy.application.member.dto.MemberLoginResponseDTO;
 import com.OEzoa.OEasy.infra.api.KakaoService;
+import com.OEzoa.OEasy.util.member.JwtTokenProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,52 +31,44 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/login")
 public class LoginController {
 
-    private final MemberService memberService;
-    private final KakaoMemberService kakaoMemberService;
-    private final KakaoService kakaoService;
+    @Autowired
+    private MemberService memberService;
+    @Autowired
+    private KakaoMemberService kakaoMemberService;
+    @Autowired
+    private KakaoService kakaoService;
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
 
-    // 일반 로그인 (JWT 활용)
+    // 일반 로그인
     @PostMapping("/oeasy")
     @Operation(
             summary = "일반 로그인",
-            description = "일반 로그인을 처리하고 JWT 토큰을 반환합니다.",
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "로그인 성공. JWT 토큰 반환."),
-                    @ApiResponse(responseCode = "401", description = "로그인 실패.")
-            }
+            description = "일반 로그인을 처리하고 JWT 토큰을 반환합니다."
     )
-    public ResponseEntity<MemberLoginResponseDTO> login(@RequestBody MemberLoginDTO memberLoginDTO, HttpSession session) {
-        MemberLoginResponseDTO responseDTO = memberService.login(memberLoginDTO, session);
-        return ResponseEntity.ok(responseDTO);
+    public ResponseEntity<MemberLoginResponseDTO> login(
+            @RequestBody MemberLoginDTO memberLoginDTO,
+            HttpServletResponse response) {
+
+        MemberLoginResponseDTO responseDTO = memberService.login(memberLoginDTO, response);
+        return ResponseEntity.ok(
+                new MemberLoginResponseDTO(responseDTO.getAccessToken(), responseDTO.getEmail(), responseDTO.getNickname())
+        );
     }
 
-    /// 카카오 로그인 콜백 - POST 요청으로 인가 코드 전달받기 (쿼리 파라미터 사용)
+    // 카카오 로그인 콜백
     @PostMapping("/kakao/callback")
     @Operation(
             summary = "카카오 API 로그인",
-            description = "카카오 API를 통해 사용자 정보를 받아 로그인을 처리하고 JWT를 반환합니다.",
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "로그인 성공. JWT 토큰 반환."),
-                    @ApiResponse(responseCode = "400", description = "알 수 없는 오류 발생.")
-            }
+            description = "카카오 API를 통해 사용자 정보를 받아 로그인을 처리하고 JWT를 반환합니다."
     )
-    public ResponseEntity<MemberLoginResponseDTO> kakaoCallback(@RequestParam("code") String code, HttpSession session) {
-        try {
-            MemberLoginResponseDTO responseDTO = kakaoMemberService.loginWithKakao(code, session);
-
-            // 반환되는 정보 확인 로그 추가
-            log.info("카카오 로그인 응답: accessToken={}, email={}, nickname={}, refreshToken={}",
-                    responseDTO.getAccessToken(),
-                    responseDTO.getRefreshToken(),
-                    responseDTO.getEmail(),
-                    responseDTO.getNickname());
-
-            // 프론트로 응답
-            return ResponseEntity.ok(responseDTO);
-        } catch (Exception e) {
-            log.error("카카오 로그인 중 오류 발생:", e);
-            return ResponseEntity.badRequest().body(null); // 오류 발생 시 ResponseEntity를 반환
-        }
+    public ResponseEntity<MemberLoginResponseDTO> kakaoCallback(
+            @RequestParam("code") String code,
+            HttpServletResponse response) throws Exception {
+        MemberLoginResponseDTO responseDTO = kakaoMemberService.loginWithKakao(code, response);
+        return ResponseEntity.ok(
+                new MemberLoginResponseDTO(responseDTO.getAccessToken(), responseDTO.getEmail(), responseDTO.getNickname())
+        );
     }
 
     // 카카오 로그인 URL 제공

--- a/src/main/java/com/OEzoa/OEasy/application/member/dto/AuthTokenResponseDTO.java
+++ b/src/main/java/com/OEzoa/OEasy/application/member/dto/AuthTokenResponseDTO.java
@@ -13,6 +13,4 @@ import lombok.Setter;
 public class AuthTokenResponseDTO {
     @Schema(description = "액세스 토큰", example = "23123123123123123123123123123214124123312312")
     private String accessToken;
-    @Schema(description = "리프레시 토큰", example = "123123123123123112312312312323123123213123123")
-    private String refreshToken;
 }

--- a/src/main/java/com/OEzoa/OEasy/application/member/dto/MemberLoginResponseDTO.java
+++ b/src/main/java/com/OEzoa/OEasy/application/member/dto/MemberLoginResponseDTO.java
@@ -4,15 +4,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
+import org.springframework.web.service.annotation.GetExchange;
 
 @Data
 @Builder
+@Getter
 @AllArgsConstructor
 public class MemberLoginResponseDTO {
     @Schema(description = "JWT 액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
     private String accessToken;
-    @Schema(description = "JWT 리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
-    private String refreshToken;
     @Schema(description = "회원 이메일", example = "example@domain.com")
     private String email;
     @Schema(description = "회원 닉네임", example = "Hyunbin Kim")

--- a/src/main/java/com/OEzoa/OEasy/application/member/mapper/MemberMapper.java
+++ b/src/main/java/com/OEzoa/OEasy/application/member/mapper/MemberMapper.java
@@ -24,21 +24,6 @@ public class MemberMapper {
                 .build();
     }
 
-    public MemberToken createMemberToken(Member member, String accessToken, String refreshToken) {
-        return MemberToken.builder()
-                .member(member)
-                .accessToken(accessToken)
-                .refreshToken(refreshToken)
-                .build();
-    }
-
-    public MemberToken updateMemberToken(MemberToken memberToken, String accessToken, String refreshToken) {
-        return memberToken.toBuilder()
-                .accessToken(accessToken)
-                .refreshToken(refreshToken)
-                .build();
-    }
-
     public Member toEntity(String email, String nickname, String hashedPassword, String salt) {
         return Member.builder()
                 .email(email)
@@ -48,10 +33,9 @@ public class MemberMapper {
                 .build();
     }
 
-    public MemberLoginResponseDTO toLoginResponseDTO(Member member, String accessToken, String refreshToken) {
+    public MemberLoginResponseDTO toLoginResponseDTO(Member member, String accessToken) {
         return MemberLoginResponseDTO.builder()
                 .accessToken(accessToken)
-                .refreshToken(refreshToken)
                 .email(member.getEmail())
                 .nickname(member.getNickname())
                 .build();

--- a/src/main/java/com/OEzoa/OEasy/application/member/mapper/MemberTokenMapper.java
+++ b/src/main/java/com/OEzoa/OEasy/application/member/mapper/MemberTokenMapper.java
@@ -6,10 +6,9 @@ import org.springframework.stereotype.Component;
 @Component
 public class MemberTokenMapper {
 
-    public MemberToken updateToken(MemberToken memberToken, String newAccessToken, String newRefreshToken) {
+    public MemberToken updateToken(MemberToken memberToken, String newAccessToken) {
         return memberToken.toBuilder()
                 .accessToken(newAccessToken)
-                .refreshToken(newRefreshToken)
                 .build();
     }
 }

--- a/src/main/java/com/OEzoa/OEasy/util/member/JwtTokenProvider.java
+++ b/src/main/java/com/OEzoa/OEasy/util/member/JwtTokenProvider.java
@@ -6,12 +6,15 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.Base64;
 import java.util.Date;
 import java.util.Map;
 import javax.crypto.SecretKey;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -21,7 +24,7 @@ public class JwtTokenProvider {
     @Value("${jwt.secret-key}")
     private String secretKeyPlain;  // 설정 파일로부터 읽어올 비밀 키 (평문 상태)
 
-    private final long TOKEN_VALIDITY = 1000L * 60 * 60 * 12;  // 액세스 토큰 유효 시간: 1분
+    private final long TOKEN_VALIDITY = 1000L * 60 * 60 * 2;  // 액세스 토큰 유효 시간: 2시간
     private final long LOGIN_TOKEN_VALIDITY = 1000L * 60 * 10;  // 회원가입 토큰 유효 시간: 10분
     private final long REFRESH_TOKEN_VALIDITY = 1000L * 60 * 60 * 24 * 7;  // 리프레시 토큰 유효 시간: 7일
     private SecretKey secretKey;  // 실제 서명 및 검증에 사용할 인코딩된 비밀 키
@@ -44,6 +47,22 @@ public class JwtTokenProvider {
                 .setExpiration(validity)  // 만료 시간 설정
                 .signWith(secretKey, SignatureAlgorithm.HS256)  // 서명에 SecretKey 사용
                 .compact();  // 토큰 생성
+    }
+
+    public String generateTokenWithData(Map<String, Object> data) {
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + LOGIN_TOKEN_VALIDITY);
+        log.info("JWT 생성 - 입력 데이터: {}", data);
+
+        // JWT 생성
+        String token = Jwts.builder()
+                .setClaims(data) // 데이터를 클레임으로 저장
+                .setIssuedAt(now) // 토큰 발행 시간
+                .setExpiration(validity) // 만료 시간
+                .signWith(secretKey, SignatureAlgorithm.HS256) // 서명
+                .compact();
+        log.info("JWT 생성 완료: {}", token);
+        return token;
     }
 
     // JWT 리프레시 토큰 생성 메서드
@@ -70,50 +89,6 @@ public class JwtTokenProvider {
         return Long.parseLong(claims.getSubject());  // 사용자 ID 추출
     }
 
-    // 토큰 만료 여부 확인 메서드
-    public boolean isTokenExpired(String token) {
-        try {
-            Claims claims = Jwts.parserBuilder()
-                    .setSigningKey(secretKey)  // 만료 검증에 사용할 SecretKey
-                    .build()
-                    .parseClaimsJws(token)
-                    .getBody();
-            return claims.getExpiration().before(new Date());  // 만료 시간 확인
-        } catch (ExpiredJwtException e) {
-            return true;  // 만료된 경우 예외 발생
-        }
-    }
-    // 리프레시 토큰이 유효한지 확인하는 메서드
-    public boolean isRefreshTokenExpired(String refreshToken) {
-        try {
-            Claims claims = Jwts.parserBuilder()
-                    .setSigningKey(secretKey)
-                    .build()
-                    .parseClaimsJws(refreshToken)
-                    .getBody();
-            return claims.getExpiration().before(new Date());
-        } catch (ExpiredJwtException e) {
-            return true;
-        }
-    }
-
-    // 회원가입 전용 JWT
-    public String generateTokenWithData(Map<String, Object> data) {
-        Date now = new Date();
-        Date validity = new Date(now.getTime() + LOGIN_TOKEN_VALIDITY);
-        log.info("JWT 생성 - 입력 데이터: {}", data);
-
-        // JWT 생성
-        String token = Jwts.builder()
-                .setClaims(data) // 데이터를 클레임으로 저장
-                .setIssuedAt(now) // 토큰 발행 시간
-                .setExpiration(validity) // 만료 시간
-                .signWith(secretKey, SignatureAlgorithm.HS256) // 서명
-                .compact();
-        log.info("JWT 생성 완료: {}", token);
-        return token;
-    }
-
     // JWT 데이터 추출
     public Map<String, Object> extractDataFromToken(String token) {
         Claims claims = Jwts.parserBuilder()
@@ -122,5 +97,20 @@ public class JwtTokenProvider {
                 .parseClaimsJws(token)
                 .getBody();
         return claims;
+    }
+
+    // Refresh Token을 HttpOnly 쿠키로 설정
+    public void createRefreshTokenCookie(Long userId, HttpServletResponse response) {
+        String refreshToken = generateRefreshToken(userId);
+
+        ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(REFRESH_TOKEN_VALIDITY)
+                .sameSite("None")
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+        log.info("Refresh Token 쿠키 생성 완료: {}", refreshCookie);
     }
 }


### PR DESCRIPTION
* 기존 로그인 및 카카오 로그인 시 발급되던 JWT 토큰 저장 방식 변경
- 프론트에게 String 으로 전달하던 액세스, 리프레시 토큰은 HttpOnly 쿠키로 관리
- DB에 저장은 고려해봐야 할듯